### PR TITLE
Do not change case of environment variable names

### DIFF
--- a/flatmap/flatmap.go
+++ b/flatmap/flatmap.go
@@ -3,7 +3,6 @@ package flatmap
 import (
 	"fmt"
 	"reflect"
-	"strings"
 )
 
 // Flatten takes a structure and turns into a flat map[string]interface{}.
@@ -34,7 +33,7 @@ func flatten(result map[string]interface{}, prefix string, v reflect.Value) {
 	case reflect.Slice:
 		flattenSlice(result, prefix, v)
 	default:
-		result[strings.ToUpper(prefix)] = v.Interface()
+		result[prefix] = v.Interface()
 	}
 }
 

--- a/flatmap/flatmap.go
+++ b/flatmap/flatmap.go
@@ -6,22 +6,24 @@ import (
 	"strings"
 )
 
+var UppercaseKeys = true
+
 // Flatten takes a structure and turns into a flat map[string]interface{}.
 //
 // Within the "thing" parameter, only primitive values are allowed. Structs are
 // not supported. Therefore, it can only be slices, maps, primitives, and
 // any combination of those together.
-func Flatten(thing map[string]interface{}, uppercaseKeys bool) map[string]interface{} {
+func Flatten(thing map[string]interface{}) map[string]interface{} {
 	result := make(map[string]interface{})
 
 	for k, raw := range thing {
-		flatten(result, k, reflect.ValueOf(raw), uppercaseKeys)
+		flatten(result, k, reflect.ValueOf(raw))
 	}
 
 	return result
 }
 
-func flatten(result map[string]interface{}, prefix string, v reflect.Value, uppercaseKeys bool) {
+func flatten(result map[string]interface{}, prefix string, v reflect.Value) {
 	if v.Kind() == reflect.Interface {
 		v = v.Elem()
 	}
@@ -30,18 +32,18 @@ func flatten(result map[string]interface{}, prefix string, v reflect.Value, uppe
 	case reflect.Invalid:
 		return
 	case reflect.Map:
-		flattenMap(result, prefix, v, uppercaseKeys)
+		flattenMap(result, prefix, v)
 	case reflect.Slice:
-		flattenSlice(result, prefix, v, uppercaseKeys)
+		flattenSlice(result, prefix, v)
 	default:
-		if uppercaseKeys {
+		if UppercaseKeys {
 			prefix = strings.ToUpper(prefix)
 		}
 		result[prefix] = v.Interface()
 	}
 }
 
-func flattenMap(result map[string]interface{}, prefix string, v reflect.Value, uppercaseKeys bool) {
+func flattenMap(result map[string]interface{}, prefix string, v reflect.Value) {
 	for _, k := range v.MapKeys() {
 		if k.Kind() == reflect.Interface {
 			k = k.Elem()
@@ -51,14 +53,14 @@ func flattenMap(result map[string]interface{}, prefix string, v reflect.Value, u
 			panic(fmt.Sprintf("%s: map key is not string: %s", prefix, k))
 		}
 
-		flatten(result, fmt.Sprintf("%s_%s", prefix, k.String()), v.MapIndex(k), uppercaseKeys)
+		flatten(result, fmt.Sprintf("%s_%s", prefix, k.String()), v.MapIndex(k))
 	}
 }
 
-func flattenSlice(result map[string]interface{}, prefix string, v reflect.Value, uppercaseKeys bool) {
+func flattenSlice(result map[string]interface{}, prefix string, v reflect.Value) {
 	prefix = prefix + "_"
 
 	for i := 0; i < v.Len(); i++ {
-		flatten(result, fmt.Sprintf("%s%d", prefix, i), v.Index(i), uppercaseKeys)
+		flatten(result, fmt.Sprintf("%s%d", prefix, i), v.Index(i))
 	}
 }

--- a/flatmap/flatmap.go
+++ b/flatmap/flatmap.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// Flag to uppercase keys in the flat map
 var UppercaseKeys = true
 
 // Flatten takes a structure and turns into a flat map[string]interface{}.

--- a/flatmap/flatmap_test.go
+++ b/flatmap/flatmap_test.go
@@ -72,7 +72,7 @@ func TestFlatten(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual := Flatten(tc.Input)
+		actual := Flatten(tc.Input, true)
 		if !reflect.DeepEqual(actual, map[string]interface{}(tc.Output)) {
 			t.Fatalf(
 				"Input:\n\n%#v\n\nOutput:\n\n%#v\n\nExpected:\n\n%#v\n",

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/ahmetalpbalkan/go-linq"
 	"github.com/op/go-logging"
 	"github.com/zeroturnaround/configo/exec"
+	"github.com/zeroturnaround/configo/flatmap"
 	"github.com/zeroturnaround/configo/sources"
 	"os"
 	"strconv"
@@ -113,14 +114,12 @@ func resolveAll(environ []string) error {
 		return nil
 	}
 
-	uppercaseKeys := true
 	if os.Getenv("CONFIGO_UPPERCASE_KEYS") == "0" {
-		uppercaseKeys = false
+		flatmap.UppercaseKeys = false
 	}
 
 	loader := sources.CompositeSource{
 		Sources: rawSources,
-		UppercaseKeys: uppercaseKeys,
 	}
 
 	resultEnv, err := loader.Get()

--- a/main.go
+++ b/main.go
@@ -113,8 +113,14 @@ func resolveAll(environ []string) error {
 		return nil
 	}
 
+	uppercaseKeys := true
+	if os.Getenv("CONFIGO_UPPERCASE_KEYS") == "0" {
+		uppercaseKeys = false
+	}
+
 	loader := sources.CompositeSource{
 		Sources: rawSources,
+		UppercaseKeys: uppercaseKeys,
 	}
 
 	resultEnv, err := loader.Get()

--- a/sources/composite.go
+++ b/sources/composite.go
@@ -38,7 +38,7 @@ func (compositeSource *CompositeSource) Get() (map[string]interface{}, error) {
 		}).
 		AsSequential().
 		CountBy(func(partialConfig T) (bool, error) {
-			for key, value := range flatmap.Flatten(partialConfig.(map[string]interface{}), compositeSource.UppercaseKeys) {
+			for key, value := range flatmap.Flatten(partialConfig.(map[string]interface{})) {
 				resultEnv[key] = value
 			}
 			return true, nil

--- a/sources/composite.go
+++ b/sources/composite.go
@@ -8,6 +8,7 @@ import (
 
 type CompositeSource struct {
 	Sources []map[string]interface{} `json:"sources"`
+	UppercaseKeys bool
 }
 
 func (compositeSource *CompositeSource) Get() (map[string]interface{}, error) {
@@ -37,7 +38,7 @@ func (compositeSource *CompositeSource) Get() (map[string]interface{}, error) {
 		}).
 		AsSequential().
 		CountBy(func(partialConfig T) (bool, error) {
-			for key, value := range flatmap.Flatten(partialConfig.(map[string]interface{})) {
+			for key, value := range flatmap.Flatten(partialConfig.(map[string]interface{}), compositeSource.UppercaseKeys) {
 				resultEnv[key] = value
 			}
 			return true, nil

--- a/sources/composite.go
+++ b/sources/composite.go
@@ -8,7 +8,6 @@ import (
 
 type CompositeSource struct {
 	Sources []map[string]interface{} `json:"sources"`
-	UppercaseKeys bool
 }
 
 func (compositeSource *CompositeSource) Get() (map[string]interface{}, error) {

--- a/spec/integration/sources/composite.bats
+++ b/spec/integration/sources/composite.bats
@@ -61,3 +61,52 @@ EOC
   assert_success "123
 456"
 }
+
+@test "sources: composite with uppercasing keys" {
+  run_container <<EOC
+  export CONFIGO_SOURCE_0='{
+    "type": "composite",
+    "sources": [
+        {
+            "type": "shell",
+            "format": "properties",
+            "command": "echo MY_COOL_PROP_1=123"
+        },
+        {
+            "type": "shell",
+            "format": "properties",
+            "command": "echo my_cool_prop_1=override"
+        }
+    ]
+}'
+  configo printenv MY_COOL_PROP_1
+EOC
+
+  assert_success "override"
+}
+
+@test "sources: composite without uppercasing keys" {
+  run_container <<EOC
+  export CONFIGO_SOURCE_0='{
+    "type": "composite",
+    "sources": [
+        {
+            "type": "shell",
+            "format": "properties",
+            "command": "echo MY_COOL_PROP_1=123"
+        },
+        {
+            "type": "shell",
+            "format": "properties",
+            "command": "echo my_cool_prop_1=override"
+        }
+    ]
+}'
+  export CONFIGO_UPPERCASE_KEYS=0
+  configo printenv MY_COOL_PROP_1
+  configo printenv my_cool_prop_1
+EOC
+
+  assert_success "123
+override"
+}


### PR DESCRIPTION
Configo makes all environment variable names uppercased. In some cases its unacceptable.